### PR TITLE
Change propertyvalueconverter IsValue check for Source prop level to be string based

### DIFF
--- a/src/TestSite.13/appsettings.Development.json
+++ b/src/TestSite.13/appsettings.Development.json
@@ -23,6 +23,9 @@
     },
     "Umbraco": {
         "CMS": {
+            "DeliveryApi": {
+                "Enabled": true
+            },
             "Unattended": {
                 "InstallUnattended": true,
                 "UnattendedUserName": "Administrator",

--- a/src/jcdcdev.Umbraco.ReadingTime.sln
+++ b/src/jcdcdev.Umbraco.ReadingTime.sln
@@ -41,7 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Github", "Github", "{5830A8
 		..\.github\dependabot.yml = ..\.github\dependabot.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSite.10", "TestSite.10\TestSite.10.csproj", "{53BFA9E1-2748-4FEE-B3CB-98172460795D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestSite.13", "TestSite.13\TestSite.13.csproj", "{53BFA9E1-2748-4FEE-B3CB-98172460795D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "jcdcdev.Umbraco.ReadingTime", "jcdcdev.Umbraco.ReadingTime\jcdcdev.Umbraco.ReadingTime.csproj", "{2060F159-0A7B-4484-A6C2-1995A3EF19B4}"
 EndProject

--- a/src/jcdcdev.Umbraco.ReadingTime/Core/PropertyEditors/ReadingTimePropertyValueConverter.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Core/PropertyEditors/ReadingTimePropertyValueConverter.cs
@@ -79,7 +79,7 @@ public class ReadingTimePropertyValueConverter : IPropertyValueConverter
 
     public bool? IsValue(object? value, PropertyValueLevel level) => level switch
     {
-        PropertyValueLevel.Source => value is Guid,
+        PropertyValueLevel.Source => value is string valueAsString && !string.IsNullOrWhiteSpace(valueAsString),
         PropertyValueLevel.Inter => value is Guid,
         PropertyValueLevel.Object => value is ReadingTimeValueModel,
         _ => throw new NotSupportedException($"Invalid level: {level}.")


### PR DESCRIPTION
DB stores info as `<span>XXX TIMEUNIT-STRING </span>` not as a GUID so the IsValue check will always fail at the moment when checking the value at PropertyLevel => Source, and the Delivery API depends on it to succeed and proceed with its own pipeline

Fixes #188 