### PR TITLE
Fix for #199 - Proper delete of all descendant keys in tree during delete/empty bin operations

### DIFF
--- a/src/jcdcdev.Umbraco.ReadingTime/Core/IReadingTimeService.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Core/IReadingTimeService.cs
@@ -9,6 +9,7 @@ public interface IReadingTimeService
     Task ScanAll();
     Task Process(IContent item);
     Task<int> DeleteAsync(Guid key);
+    Task<int> DeleteAsync(IEnumerable<Guid> keys);
     Task<ReadingTimeDto?> GetAsync(Guid key, Guid dataTypeKey);
     Task<ReadingTimeDto?> GetAsync(Guid key, int dataTypeId);
 }

--- a/src/jcdcdev.Umbraco.ReadingTime/Core/ReadingTimeNotificationHandler.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Core/ReadingTimeNotificationHandler.cs
@@ -4,7 +4,6 @@ using jcdcdev.Umbraco.ReadingTime.Core.Extensions;
 using jcdcdev.Umbraco.ReadingTime.Core.PropertyEditors;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
@@ -18,18 +17,41 @@ public class ReadingTimeNotificationHandler :
 {
     private readonly ILocalizedTextService _localizedTextService;
     private readonly IReadingTimeService _readingTimeService;
+    private readonly IContentService _contentService;
 
-    public ReadingTimeNotificationHandler(IReadingTimeService readingTimeService, ILocalizedTextService localizedTextService)
+    private const int ChildrenPageSize = 1000;
+
+    public ReadingTimeNotificationHandler(IReadingTimeService readingTimeService, ILocalizedTextService localizedTextService, IContentService contentService)
     {
         _readingTimeService = readingTimeService;
         _localizedTextService = localizedTextService;
+        _contentService = contentService;
     }
 
+    // Both ContentDeletingNotification and ContentEmptyingRecycleBinNotification are called during emptying a global Recycle Bin empty operation
+    // Since individual deletes from within the Bin trigger just the ContentDeletingNotification and not the latter, this should cover both use cases
     public async Task HandleAsync(ContentDeletingNotification notification, CancellationToken cancellationToken)
     {
-        foreach (var content in notification.DeletedEntities)
+        foreach (var item in notification.DeletedEntities)
         {
-            await _readingTimeService.DeleteAsync(content.Key);
+            var toDelete = new List<Guid> { item.Key };
+            var pageIndex = 0;
+
+            List<Guid> pagedDescendants;
+
+            do
+            {
+                pagedDescendants = _contentService
+                    .GetPagedDescendants(item.Id, pageIndex, ChildrenPageSize, out _)
+                    .Select(x => x.Key)
+                    .ToList();
+
+                toDelete.AddRange(pagedDescendants);
+
+                pageIndex++;
+            } while (pagedDescendants.Count == ChildrenPageSize);
+
+            await _readingTimeService.DeleteAsync(toDelete);
         }
     }
 

--- a/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/Persistence/IReadingTimeRepository.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/Persistence/IReadingTimeRepository.cs
@@ -6,6 +6,7 @@ namespace jcdcdev.Umbraco.ReadingTime.Infrastructure.Persistence;
 public interface IReadingTimeRepository
 {
     Task<int> DeleteAsync(Guid key);
+    Task<int> DeleteAsync(IEnumerable<Guid> key);
     Task<ReadingTimeDto> GetOrCreate(Guid key, IDataType dataType);
     Task PersistAsync(ReadingTimeDto dto);
     Task<ReadingTimeDto?> Get(Guid key, int dataTypeId);

--- a/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/Persistence/ReadingTimeRepository.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/Persistence/ReadingTimeRepository.cs
@@ -31,6 +31,22 @@ public class ReadingTimeRepository : IReadingTimeRepository
         return Task.FromResult(data);
     }
 
+    public Task<int> DeleteAsync(IEnumerable<Guid> keys)
+    {
+        using var scope = _scopeProvider.CreateScope();
+
+        var sql = scope.SqlContext
+            .Sql()
+            .Delete<ReadingTimePoco>()
+            .WhereIn<ReadingTimePoco>(x => x.Key, keys);
+
+        var data = scope.Database.Execute(sql);
+
+        scope.Complete();
+
+        return Task.FromResult(data);
+    }
+
     public async Task<ReadingTimeDto> GetOrCreate(Guid key, IDataType dataType)
     {
         var dto = await Get(key, dataType.Id);

--- a/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/ReadingTimeService.cs
+++ b/src/jcdcdev.Umbraco.ReadingTime/Infrastructure/ReadingTimeService.cs
@@ -42,6 +42,12 @@ public class ReadingTimeService : IReadingTimeService
         return await _readingTimeRepository.DeleteAsync(key);
     }
 
+    public async Task<int> DeleteAsync(IEnumerable<Guid> keys)
+    {
+        _logger.LogDebug("Deleting reading time for {Keys}", keys);
+        return await _readingTimeRepository.DeleteAsync(keys);
+    }
+
     public async Task ScanTree(int homeId)
     {
         var content = _contentService.GetById(homeId);


### PR DESCRIPTION
I've kept the single key delete in the interface for compatibility (it's a public interface on public services, so never know if someone on U13 decided to hook and use these methods by themselves)

U16 version of the package still uses the delete/DB storage, while the 17+ versions seem to store the value directly in the IContent only, and the DB is completely gone.

@jcdcdev U16 is already EOL so don't think we need to propagate this bug fix to it. And the 17 version shouldn't need any fix at all due to how the package changed how it works.

-----

What this fixes:
- If a parent with multiple children/descendants is "deleted" (moved to Bin), and then said parent properly deleted from the Bin itself, both the parent and all its descendants will have it's related rows deleted from the ReadingTime DB
- If a global bin empty action is triggered, instead of just the "root" items in the Recycle Bin being cleaned up on the ReadingTime DB, all the descendants are also properly cleaned.

This should prevent Foreign Key constraint errors that would prevent the actions mentioned above from completing successfully.

Testing this is simple:

1. Take the current sample site and create + publish multiple copies of the homepage at the root of the content tree.
2. "Delete" one of these homes.
3. On the Recycle Bin, delete one of the children only, not the parent. Everything should work as normal, as those children have no descendants.
4. Now delete the home from the recycle bin. Before the fix this would raise a FK error, now it should work fine.
5. Delete 1-2 of the remaining home nodes from the published content tree.
6. Trigger a empty recycle bin action
7. Everything should work and delete as expected instead of throwing a FK error on the UI


I've kept the pagination to 1000 so it's not completely unbounded (`int.MaxValue`) in case, there's some really _**stinky**_ bins somewhere using this package, that might drown the DB out from doing such an unbounded fetch, but it's also not ridiculously low (50-100) and risk slowing down the empty operation by too much.